### PR TITLE
fix wrong scss bulma variables import for new bulma version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tabs component for Vue Bulma",
   "main": "src/index.js",
   "peerDependencies": {
-    "bulma": ">=0.2",
+    "bulma": ">=0.6",
     "vue": ">=2"
   },
   "scripts": {},

--- a/src/Tabs.vue
+++ b/src/Tabs.vue
@@ -111,7 +111,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~bulma/sass/utilities/variables';
+@import '~bulma/sass/utilities/initial-variables';
 
 .vue-bulma-tabs {
   position: relative;


### PR DESCRIPTION
This commit fix 
``` File to import not found or unreadable: ~bulma/sass/utilities/variables.```
In new Bulma version this file is named initial-variables.